### PR TITLE
Add-on connection with wrong certificate

### DIFF
--- a/02-create-certificates.sh
+++ b/02-create-certificates.sh
@@ -1,59 +1,59 @@
 #!/bin/bash
 
-mkdir -p ca-private
-mkdir -p ca-cert
-mkdir -p server-private
-mkdir -p server-cert
-mkdir -p client-private
-mkdir -p client-cert
+mkdir -p ca-private-1
+mkdir -p ca-cert-1
+mkdir -p server-private-1
+mkdir -p server-cert-1
+mkdir -p client-private-1
+mkdir -p client-cert-1
 
 #Step 1: Generate CA private key
-if [ ! -f $PWD/ca-private/ca-private-key.pem ]; then
-    docker run --rm -it -w /home -v $PWD:/home svagi/openssl genrsa -out /home/ca-private/ca-private-key.pem 2048
+if [ ! -f $PWD/ca-private-1/ca-private-key-1.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl genrsa -out /home/ca-private-1/ca-private-key-1.pem 2048
     echo 'Step 1: CA private key created'
 else
     echo 'Step 1: CA private key already exists'
 fi
 
 #Step 2: Generate CA certificate using the private key
-if [ ! -f $PWD/ca-cert/ca-cert.pem ]; then
-    docker run --rm -it -w /home -v $PWD:/home svagi/openssl req -sha1 -new -x509 -nodes -days 3650 -key /home/ca-private/ca-private-key.pem \
-    -out /home/ca-cert/ca-cert.pem -subj "/C=GB/ST=Greater London/L=London/O=Dell EMC/OU=AWG/CN=awg.dell.com"
+if [ ! -f $PWD/ca-cert-1/ca-cert-1.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl req -sha1 -new -x509 -nodes -days 3650 -key /home/ca-private-1/ca-private-key-1.pem \
+    -out /home/ca-cert-1/ca-cert-1.pem -subj "/C=GB/ST=Greater London/L=London/O=Dell EMC/OU=AWG/CN=awg.dell.com"
     echo 'Step 2: CA certificate created'
 else
     echo 'Step 2: CA certificate already exists'
 fi
 
 #Step 3: Generate private server key and signing request
-if [ ! -f $PWD/server-private/server-private-key.pem ]; then
-    docker run --rm -it -w /home -v $PWD:/home svagi/openssl req -sha1 -newkey rsa:2048 -days 730 -nodes -keyout /home/server-private/server-private-key.pem \
-    -out /home/server-private/server-key-signing-req.pem -subj "/C=GB/ST=Greater London/L=London/O=Dell EMC/OU=AWG/CN=mysql.awg.dell.com"
+if [ ! -f $PWD/server-private-1/server-private-key-1.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl req -sha1 -newkey rsa:2048 -days 730 -nodes -keyout /home/server-private-1/server-private-key-1.pem \
+    -out /home/server-private-1/server-key-signing-req-1.pem -subj "/C=GB/ST=Greater London/L=London/O=Dell EMC/OU=AWG/CN=mysql.awg.dell.com"
     echo 'Step 3: Private server key and signing request created'
 else
     echo 'Step 3: Private server key already exists'
 fi
 
 #Step 4: Export private server key to RSA private key
-if [ ! -f $PWD/server-private/server-private-key-rsa.pem ]; then
-    docker run --rm -it -w /home -v $PWD:/home svagi/openssl rsa -in /home/server-private/server-private-key.pem -out /home/server-private/server-private-key-rsa.pem
+if [ ! -f $PWD/server-private-1/server-private-key-rsa-1.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl rsa -in /home/server-private-1/server-private-key-1.pem -out /home/server-private-1/server-private-key-rsa-1.pem
     echo 'Step 4: Private server key expoerted to RSA format'
 else
     echo 'Step 4: Private server key already exists in RSA format'
 fi
 
 #Step 5: Create server certificate based on server signing request
-if [ ! -f $PWD/server-cert/server-cert.pem ]; then
-    docker run --rm -it -w /home -v $PWD:/home svagi/openssl x509 -sha1 -req -in /home/server-private/server-key-signing-req.pem \
-    -days 730  -CA /home/ca-cert/ca-cert.pem -CAkey /home/ca-private/ca-private-key.pem -set_serial 01 -out /home/server-cert/server-cert.pem
+if [ ! -f $PWD/server-cert-1/server-cert-1.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl x509 -sha1 -req -in /home/server-private-1/server-key-signing-req-1.pem \
+    -days 730  -CA /home/ca-cert-1/ca-cert-1.pem -CAkey /home/ca-private-1/ca-private-key-1.pem -set_serial 01 -out /home/server-cert-1/server-cert-1.pem
     echo 'Step 5: Server certificate created.'
 else
     echo 'Step 5: Server certificate already exists.'
 fi
 
 #Step 6: Create private client key and signing request
-if [ ! -f $PWD/client-private/client-private-key.pem ]; then
+if [ ! -f $PWD/client-private-1/client-private-key-1.pem ]; then
     docker run --rm -it -w /home -v $PWD:/home svagi/openssl req -sha1 -newkey rsa:2048 -days 730 -nodes \
-    -keyout /home/client-private/client-private-key.pem -out /home/client-private/client-key-signing-req.pem \
+    -keyout /home/client-private-1/client-private-key-1.pem -out /home/client-private-1/client-key-signing-req-1.pem \
     -subj "/C=GB/ST=Greater London/L=London/O=Dell EMC/OU=AWG/CN=client.awg.dell.com"
     echo 'Step 6: Client private key and signing request created.'
 else
@@ -61,18 +61,18 @@ else
 fi
 
 #Step 7: Export private client key to RSA private key
-if [ ! -f $PWD/client-private/client-private-key-rsa.pem ]; then
-    docker run --rm -it -w /home -v $PWD:/home svagi/openssl rsa -in /home/client-private/client-private-key.pem \
-    -out /home/client-private/client-private-key-rsa.pem
+if [ ! -f $PWD/client-private-1/client-private-key-rsa-1.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl rsa -in /home/client-private-1/client-private-key-1.pem \
+    -out /home/client-private-1/client-private-key-rsa-1.pem
     echo 'Step 7: Private client key exported to RSA format'
 else
     echo 'Step 7: Private client key already exists in RSA format'
 fi
 
 #Step 8: Sign client certificate:w
-if [ ! -f $PWD/client-cert/client-cert.pem ]; then
-    docker run --rm -it -w /home -v $PWD:/home svagi/openssl x509 -sha1 -req -in /home/client-private/client-key-signing-req.pem \
-    -days 730 -CA /home/ca-cert/ca-cert.pem -CAkey /home/ca-private/ca-private-key.pem -set_serial 01 -out /home/client-cert/client-cert.pem
+if [ ! -f $PWD/client-cert-1/client-cert-1.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl x509 -sha1 -req -in /home/client-private-1/client-key-signing-req-1.pem \
+    -days 730 -CA /home/ca-cert-1/ca-cert-1.pem -CAkey /home/ca-private-1/ca-private-key-1.pem -set_serial 01 -out /home/client-cert-1/client-cert-1.pem
     echo 'Step 8: Client certificate created'
 else
     echo 'Step 8: Client certificate already exists'

--- a/03-setup-mariadb-server.sh
+++ b/03-setup-mariadb-server.sh
@@ -10,5 +10,5 @@ else
 fi
 
 docker run --name sslmaria -v $PWD:/etc/mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mariadb \
---ssl-ca=/etc/mysql/ca-cert/ca-cert.pem --ssl-cert=/etc/mysql/server-cert/server-cert.pem \
---ssl-key=/etc/mysql/server-private/server-private-key-rsa.pem  --bind-address=*
+--ssl-ca=/etc/mysql/ca-cert-1/ca-cert-1.pem --ssl-cert=/etc/mysql/server-cert-1/server-cert-1.pem \
+--ssl-key=/etc/mysql/server-private-1/server-private-key-rsa-1.pem  --bind-address=*

--- a/06-create-new-certificates.sh
+++ b/06-create-new-certificates.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+mkdir -p ca-private-2
+mkdir -p ca-cert-2
+mkdir -p server-private-2
+mkdir -p server-cert-2
+mkdir -p client-private-2
+mkdir -p client-cert-2
+
+#Step 1: Generate CA private key
+if [ ! -f $PWD/ca-private-2/ca-private-key-2.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl genrsa -out /home/ca-private-2/ca-private-key-2.pem 2048
+    echo 'Step 1: CA private key created'
+else
+    echo 'Step 1: CA private key already exists'
+fi
+
+#Step 2: Generate CA certificate using the private key
+if [ ! -f $PWD/ca-cert-2/ca-cert-2.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl req -sha1 -new -x509 -nodes -days 3650 -key /home/ca-private-2/ca-private-key-2.pem \
+    -out /home/ca-cert-2/ca-cert-2.pem -subj "/C=GB/ST=Greater London/L=London/O=Dell EMC/OU=AWG/CN=awg.dell.com"
+    echo 'Step 2: CA certificate created'
+else
+    echo 'Step 2: CA certificate already exists'
+fi
+
+#Step 3: Generate private server key and signing request
+if [ ! -f $PWD/server-private-2/server-private-key-2.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl req -sha1 -newkey rsa:2048 -days 730 -nodes -keyout /home/server-private-2/server-private-key-2.pem \
+    -out /home/server-private-2/server-key-signing-req-2.pem -subj "/C=GB/ST=Greater London/L=London/O=Dell EMC/OU=AWG/CN=mysql.awg.dell.com"
+    echo 'Step 3: Private server key and signing request created'
+else
+    echo 'Step 3: Private server key already exists'
+fi
+
+#Step 4: Export private server key to RSA private key
+if [ ! -f $PWD/server-private-2/server-private-key-rsa-2.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl rsa -in /home/server-private-2/server-private-key-2.pem -out /home/server-private-2/server-private-key-rsa-2.pem
+    echo 'Step 4: Private server key expoerted to RSA format'
+else
+    echo 'Step 4: Private server key already exists in RSA format'
+fi
+
+#Step 5: Create server certificate based on server signing request
+if [ ! -f $PWD/server-cert-2/server-cert-2.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl x509 -sha1 -req -in /home/server-private-2/server-key-signing-req-2.pem \
+    -days 730  -CA /home/ca-cert-2/ca-cert-2.pem -CAkey /home/ca-private-2/ca-private-key-2.pem -set_serial 01 -out /home/server-cert-2/server-cert-2.pem
+    echo 'Step 5: Server certificate created.'
+else
+    echo 'Step 5: Server certificate already exists.'
+fi
+
+#Step 6: Create private client key and signing request
+if [ ! -f $PWD/client-private-2/client-private-key-2.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl req -sha1 -newkey rsa:2048 -days 730 -nodes \
+    -keyout /home/client-private-2/client-private-key-2.pem -out /home/client-private-2/client-key-signing-req-2.pem \
+    -subj "/C=GB/ST=Greater London/L=London/O=Dell EMC/OU=AWG/CN=client.awg.dell.com"
+    echo 'Step 6: Client private key and signing request created.'
+else
+    echo 'Step 6: Client server key already exists'
+fi
+
+#Step 7: Export private client key to RSA private key
+if [ ! -f $PWD/client-private-2/client-private-key-rsa-2.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl rsa -in /home/client-private-2/client-private-key-2.pem \
+    -out /home/client-private-2/client-private-key-rsa-2.pem
+    echo 'Step 7: Private client key exported to RSA format'
+else
+    echo 'Step 7: Private client key already exists in RSA format'
+fi
+
+#Step 8: Sign client certificate:w
+if [ ! -f $PWD/client-cert-2/client-cert-2.pem ]; then
+    docker run --rm -it -w /home -v $PWD:/home svagi/openssl x509 -sha1 -req -in /home/client-private-2/client-key-signing-req-2.pem \
+    -days 730 -CA /home/ca-cert-2/ca-cert-2.pem -CAkey /home/ca-private-2/ca-private-key-2.pem -set_serial 01 -out /home/client-cert-2/client-cert-2.pem
+    echo 'Step 8: Client certificate created'
+else
+    echo 'Step 8: Client certificate already exists'
+fi
+
+
+
+

--- a/07-connect-via-client-container-wrong-cert.sh
+++ b/07-connect-via-client-container-wrong-cert.sh
@@ -4,5 +4,5 @@ SSLMARIAIP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' sslmaria)
 
 docker run -it --rm -w /home -v $PWD:/home --name mariaclient --link sslmaria:mysql mariadb \
 mysql -h"$SSLMARIAIP" -P3306 -uiamsecure -piamsecurepwd \
---ssl-ca=/home/ca-cert-1/ca-cert-1.pem --ssl-cert=/home/client-cert-1/client-cert-1.pem \
---ssl-key=/home/client-private-1/client-private-key-rsa-1.pem
+--ssl-ca=/home/ca-cert-2/ca-cert-2.pem --ssl-cert=/home/client-cert-2/client-cert-2.pem \
+--ssl-key=/home/client-private-2/client-private-key-rsa-2.pem

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Creates a new user who must connect securely.
 **05-connect-via-client-container.sh**  
 Creates a new ephemeral container running Maria DB client, and connects to the server using `mysql`.
 
-**06-create-new-certificates.sh** 
+**06-create-new-certificates.sh**  
 Generates a new certificate authority, and signs a new certificate.
 
-**07-connect-via-client-container-wrong-cert.sh**
-Creates a new ephemeral container running Maria DB cient, and tries to connect using the newly created certificate.
+**07-connect-via-client-container-wrong-cert.sh**  
+Creates a new ephemeral container running Maria DB client, and tries to connect using the newly created certificate.
 
 
 ## Usage  

--- a/README.md
+++ b/README.md
@@ -16,16 +16,23 @@ Run the scripts in this repository in order.
 Pulls the latest OpenSSL and MariaDB containers.  
   
 **02-create-certificates.sh**  
-Creates keys and certificates.  
+Creates a certificate authority and sign one certificate.  
   
 **03-setup-mariadb-server.sh**  
-Creates a new container running Maria DB.
+Creates a new container running Maria DB server.
   
 **04-create-test-user.sh**  
 Creates a new user who must connect securely.  
 
 **05-connect-via-client-container.sh**  
-Creates a new ephemeral container running Maria DB, and connects to the server using `mysql`.
+Creates a new ephemeral container running Maria DB client, and connects to the server using `mysql`.
+
+**06-create-new-certificates.sh**
+Generates a new certificate authority and sign a new certificate
+
+**07-connect-via-client-container-wrong-cert.sh**
+Creates a new ephemeral container running Maria DB cient, and try to connect using the newly created certificate
+
 
 ## Usage  
 Type `\s` at the MySQL command prompt after running 04-connect-via-client-container.sh to verify SSL is being used.  

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Creates a new user who must connect securely.
 Creates a new ephemeral container running Maria DB client, and connects to the server using `mysql`.
 
 **06-create-new-certificates.sh**
-Generates a new certificate authority and sign a new certificate
+Generates a new certificate authority, and signs a new certificate.
 
 **07-connect-via-client-container-wrong-cert.sh**
-Creates a new ephemeral container running Maria DB cient, and try to connect using the newly created certificate
+Creates a new ephemeral container running Maria DB cient, and tries to connect using the newly created certificate.
 
 
 ## Usage  

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Run the scripts in this repository in order.
 Pulls the latest OpenSSL and MariaDB containers.  
   
 **02-create-certificates.sh**  
-Creates a certificate authority and sign one certificate.  
+Creates a certificate authority and signs one certificate.  
   
 **03-setup-mariadb-server.sh**  
 Creates a new container running Maria DB server.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Creates a new user who must connect securely.
 **05-connect-via-client-container.sh**  
 Creates a new ephemeral container running Maria DB client, and connects to the server using `mysql`.
 
-**06-create-new-certificates.sh**
+**06-create-new-certificates.sh** 
 Generates a new certificate authority, and signs a new certificate.
 
 **07-connect-via-client-container-wrong-cert.sh**


### PR DESCRIPTION
Very simple add-on to demonstrate that the client connection is refused if the client certificate isn't issued by the same certificate authority as the server certificate.

- The prefix "-1" has been appended to the directories and files generated by the script `02-create-certificates.sh`
- The  script `06-create-new-certificates.sh` has been added to generate a new ca and certificates - it sets the prefix "-2" at the end of the directories and file names.
- The script `07-connect-via-client-container-wrong-cert.sh` could be executed to demonstrate the connection being refused.
- The Readme has been updated to describe the usage.
